### PR TITLE
Dry run on non-main branches

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -61,3 +61,4 @@ jobs:
         with:
           source-repo: ${{ matrix.mirror_config.src_repo }}
           destination-repo: "git@github.com:jhnc-oss/${{ matrix.mirror_config.dest_repo }}.git"
+          dry-run: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Executes a dry run on branches other than `main`. All steps are run, but the final push doesn't transfer any data.

closes #31 