### PR TITLE
Disable sync of linux-yocto again

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -165,11 +165,12 @@ jobs:
               dest_repo: "yocto-kernel-cache",
               key_id: "YOCTO_KERNEL_CACHE",
             }
-          - {
-              src_repo: "https://git.yoctoproject.org/linux-yocto.git",
-              dest_repo: "linux-yocto",
-              key_id: "LINUX_YOCTO",
-            }
+            # Broken sync (#77)
+          # - {
+          #     src_repo: "https://git.yoctoproject.org/linux-yocto.git",
+          #     dest_repo: "linux-yocto",
+          #     key_id: "LINUX_YOCTO",
+          #   }
           - {
               src_repo: "https://github.com/nxp-imx/meta-imx.git",
               dest_repo: "meta-imx",


### PR DESCRIPTION
The sync fails even with a up-to-date destination repo (#77).