### PR TITLE
yocto-meta-kf6 mirror

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -151,6 +151,11 @@ jobs:
               key_id: "YOCTO_META_KF5",
             }
           - {
+              src_repo: "https://github.com/jhnc-oss/yocto-meta-kf6.git",
+              dest_repo: "yocto-meta-kf6",
+              key_id: "YOCTO_META_KF6",
+            }
+          - {
               src_repo: "https://github.com/mneuroth/QuickScintilla.git",
               dest_repo: "QuickScintilla",
               key_id: "QUICKSCINTILLA",


### PR DESCRIPTION
Adds yocto-meta-kf6 mirror (#82).

:information_source: The mirror is based on the Github Repo, which is in sync with invent.kde.org.