### PR TITLE
Don't fail fast (#89)

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -13,6 +13,7 @@ jobs:
   mirror-repos:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         mirror_config:
           - {


### PR DESCRIPTION
Disables *fail fast* which terminates all queued / in progress mirror once there's one failing.

closes #89 