### PR TITLE
Remove disabled mirror of linux-yocto

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -170,12 +170,6 @@ jobs:
               dest_repo: "yocto-kernel-cache",
               key_id: "YOCTO_KERNEL_CACHE",
             }
-            # Broken sync (#77)
-          # - {
-          #     src_repo: "https://git.yoctoproject.org/linux-yocto.git",
-          #     dest_repo: "linux-yocto",
-          #     key_id: "LINUX_YOCTO",
-          #   }
           - {
               src_repo: "https://github.com/nxp-imx/meta-imx.git",
               dest_repo: "meta-imx",


### PR DESCRIPTION
Removes the disabled mirror of *linux-yocto* which was disabled due to several unsuccessful attempts to get the huge repo mirrored (see #77).