### PR TITLE
Remove meta-python2

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -47,11 +47,6 @@ jobs:
               key_id: "POKY",
             }
           - {
-              src_repo: "https://git.openembedded.org/meta-python2",
-              dest_repo: "meta-python2",
-              key_id: "META_PYTHON2",
-            }
-          - {
               src_repo: "https://github.com/vmware/vsphere-automation-sdk-python.git",
               dest_repo: "vsphere-automation-sdk-python",
               key_id: "VSPHERE_AUTOMATION_SDK_PYTHON",


### PR DESCRIPTION
Removes *meta-python2* from mirror sync.

Last commit was some years ago and it's very unlikely this is going to change.

### Cleanup after merge

- [ ] Remove Key from this repo
- [ ] Remove key from dest repo