### PR TITLE
remove yocto-vex-check

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -241,11 +241,6 @@ jobs:
               key_id: "CVELISTV5",
             }
           - {
-              src_repo: "https://gitlab.com/syslinbit/public/yocto-vex-check.git",
-              dest_repo: "yocto-vex-check",
-              key_id: "YOCTO_VEX_CHECK",
-            }
-          - {
               src_repo: "https://github.com/nxp-imx/uboot-imx.git",
               dest_repo: "uboot-imx",
               key_id: "UBOOT_IMX",


### PR DESCRIPTION
Removes yocto-vex-check from mirror sync.

Work now seems to happen in YP itself and initial efforts to bring changes upstream were in vain.
In addition, the workflow shows errors lately.

Cope with remaining keys in the aftermath.