### PR TITLE
Disable CodeQL cron and build on commits

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,7 @@
 name: codeql
 
 on:
-  schedule:
-    - cron: '0 5 * * 3'
   push:
-    branches:
-      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
Cron builds get disabled automatically after some inactivity in the repo. It makes more sense to execute it on changes here.