### PR TITLE
Update meta-mingw upstream url

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -36,7 +36,7 @@ jobs:
               key_id: "META_OPENEMBEDDED",
             }
           - {
-              src_repo: "https://git.yoctoproject.org/git/meta-mingw.git",
+              src_repo: "https://git.yoctoproject.org/meta-mingw",
               dest_repo: "meta-mingw",
               key_id: "META_MINGW",
             }


### PR DESCRIPTION
Lately, sync jobs for meta-mingw repo are failing more often. The git repo URL appears to be fine, but occasionally you get an error _“No repositories found”_. The new URL is taken directly from the clone URL shown [here](https://git.yoctoproject.org/meta-mingw).