### PR TITLE
Bump wearerequired/git-mirror-action from 1.2.0 to 1.3.1

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -305,7 +305,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - uses: wearerequired/git-mirror-action@c44c68aebe42de49a80a8dfd557416b6a0cafdad
+      - uses: wearerequired/git-mirror-action@6bbc55f2f0082bca533b72dc711f7d37154d40cc
         env:
           SSH_PRIVATE_KEY: ${{ secrets[format('SSH_PRIVATE_KEY_{0}', matrix.mirror_config.key_id)] }}
           SSH_KNOWN_HOSTS: "${{ secrets.SSH_KNOWN_HOSTS }}"


### PR DESCRIPTION
The dependabot PR #144 fails since it has no permission (intentional).