### PR TITLE
Don't run mirror for callers without permission

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   mirror-repos:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -15,7 +15,6 @@ concurrency:
 
 jobs:
   mirror-repos:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -307,6 +306,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - uses: wearerequired/git-mirror-action@6bbc55f2f0082bca533b72dc711f7d37154d40cc
+        if: env.SSH_KNOWN_HOSTS != ''
         env:
           SSH_PRIVATE_KEY: ${{ secrets[format('SSH_PRIVATE_KEY_{0}', matrix.mirror_config.key_id)] }}
           SSH_KNOWN_HOSTS: "${{ secrets.SSH_KNOWN_HOSTS }}"


### PR DESCRIPTION
Dependabot doesn't have the permission to actually mirror (not even dry run). Thus, all builds fail with 'permission denied'. Same for jobs started through a fork.